### PR TITLE
Support removal of `value()` at the end of chains following `times`/`…forEach`/etc (fixes #3)

### DIFF
--- a/lib/chain-remove-value.js
+++ b/lib/chain-remove-value.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var _ = require('lodash/fp');
+
+var endingMethods = [
+  'times',
+  'forEach', 'forEachRight',
+  'each', 'eachRight',
+  'forIn', 'forInRight',
+  'forOwn', 'forOwnRight'
+];
+
+function isChainEndingMethod(node) {
+  return _.contains(node.value.callee.object.callee.property.name, endingMethods);
+}
+
+function isLodash(node) {
+  return node.type === 'Identifier' && node.name === '_';
+}
+
+function isLodashChain(node) {
+  if (isLodash(node)) {
+    return true;
+  }
+  if (node.type === 'CallExpression') {
+    return isLodashChain(node.callee);
+  }
+  if (node.type === 'MemberExpression') {
+    if (isLodash(node.object)) {
+      return node.property.type === 'Identifier' && node.property.name === 'chain';
+    }
+    return isLodashChain(node.object);
+  }
+  return false;
+}
+
+module.exports = function transformer(file, api) {
+  var j = api.jscodeshift;
+  var ast = j(file.source);
+  ast.find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      property: {
+        name: 'value'
+      },
+      object: {
+        type: 'CallExpression',
+        callee: {
+          type: 'MemberExpression',
+          property: {
+            type: 'Identifier'
+          }
+        }
+      }
+    }
+  })
+  .filter(isChainEndingMethod)
+  .filter(function (p) {
+    if (isLodashChain(p.value.callee)) {
+      return true;
+    }
+
+    // This looks like a Lodash method call, but we can't be sure it is or isn't a Lodash chain.
+    // so let's just print a warning in the console.
+    var position = [file.path, p.value.loc.start.line, p.value.loc.start.column].join(':');
+    console.warn(
+      'WARNING: In file `' + position +
+      '`, please check that the object calling `value()` is not a Lodash chain. If it is, please remove the call to `value()`, as calls to `' +
+      endingMethods.join(', ') +
+      '` now end the chain. See bulletpoint 3 of https://github.com/lodash/lodash/wiki/Changelog#jan-12-2016--diff--docs'
+    );
+    return false;
+  })
+  .replaceWith(function (p) {
+    return p.value.callee.object;
+  });
+
+  return ast.toSource();
+};

--- a/releases.json
+++ b/releases.json
@@ -5,6 +5,7 @@
         "./lib/method-calls-conditional-name-changes.js",
         "./lib/method-name-changes.js",
         "./lib/remove-category-from-import.js",
-        "./lib/this-arg-removal.js"
+        "./lib/this-arg-removal.js",
+        "./lib/chain-remove-value.js"
     ]
 }]

--- a/test/chain-remove-value.js
+++ b/test/chain-remove-value.js
@@ -1,0 +1,47 @@
+import plugin from '../lib/chain-remove-value';
+import {testPlugin, with_} from './helpers/jscodeshift-wrapper';
+
+const {test, testUnchanged} = testPlugin(plugin);
+
+test(with_('_([1, 2, 3]).times().value()'), with_('_([1, 2, 3]).times()'));
+test(with_('_([1, 2, 3]).times(3).value()'), with_('_([1, 2, 3]).times(3)'));
+test(with_('_([1, 2, 3]).forEach(fn).value()'), with_('_([1, 2, 3]).forEach(fn)'));
+test(with_('_([1, 2, 3]).each(fn).value()'), with_('_([1, 2, 3]).each(fn)'));
+test(with_('_([1, 2, 3]).forIn(fn).value()'), with_('_([1, 2, 3]).forIn(fn)'));
+test(with_('_([1, 2, 3]).forOwn(fn).value()'), with_('_([1, 2, 3]).forOwn(fn)'));
+test(with_('_([1, 2, 3]).forEachRight(fn).value()'), with_('_([1, 2, 3]).forEachRight(fn)'));
+test(with_('_([1, 2, 3]).eachRight(fn).value()'), with_('_([1, 2, 3]).eachRight(fn)'));
+test(with_('_([1, 2, 3]).forInRight(fn).value()'), with_('_([1, 2, 3]).forInRight(fn)'));
+test(with_('_([1, 2, 3]).forOwnRight(fn).value()'), with_('_([1, 2, 3]).forOwnRight(fn)'));
+test(with_('_([1, 2, 3]).times().value().concat(3)'), with_('_([1, 2, 3]).times().concat(3)'));
+test(with_(`
+  _([1, 2, 3])
+    .times()
+    .value()
+    .concat(3)
+`), with_(`
+  _([1, 2, 3])
+    .times()
+    .concat(3)
+`));
+test(with_('_.chain([1, 2, 3]).times(3).value()'), with_('_.chain([1, 2, 3]).times(3)'));
+test(with_('_.chain([1, 2, 3]).forEach(fn).value()'), with_('_.chain([1, 2, 3]).forEach(fn)'));
+
+testUnchanged(with_('_([1, 2, 3]).value()'));
+testUnchanged(with_('_([1, 2, 3]).map(fn).value()'));
+testUnchanged(with_('_([1, 2, 3]).times(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forEach(fn)'));
+testUnchanged(with_('_([1, 2, 3]).each(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forIn(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forOwn(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forEachRight(fn)'));
+testUnchanged(with_('_([1, 2, 3]).eachRight(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forInRight(fn)'));
+testUnchanged(with_('_([1, 2, 3]).forOwnRight(fn)'));
+testUnchanged(with_('_.chain([1, 2, 3]).value()'));
+testUnchanged(with_('_.chain([1, 2, 3]).map(fn).value()'));
+testUnchanged(with_('_.chain([1, 2, 3]).times(fn)'));
+testUnchanged(with_('_.get(object, path).forEach(fn).value()'));
+
+// This can potentially be an error, so it will be reported in the console.
+testUnchanged(with_('foreignAPI([1, 2, 3]).forEach(fn).value()'));


### PR DESCRIPTION
Adds a codemod to address bulletpoint 3 of https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings. Fixes #3.

It removes the value at the end of sequences when we can be sure that it's a Lodash method, or print a warning otherwise, even though it sounds pretty likely that anything that fits this is actually using Lodash. I prefer being on the "safe" side here.

@davidshepherd7 If you have some time reviewing, maybe even trying it out on your codebase at the point where it still had the `value()` calls, I'd much appreciate it :)
